### PR TITLE
Correct dependencies Boost.Timer and Boost.System

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -29,7 +29,7 @@ project boost/test
                    
                    # Adding a dependency on boost/timer as the headers need to be there in case of the 
                    # header-only usage variant
-                   <library>/boost/timer//boost_timer
+                   <use>/boost/timer//boost_timer
     ;
 
 PRG_EXEC_MON_SOURCES =

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -8,8 +8,6 @@
 
 project
     : requirements
-      <library>/boost/system//boost_system
-      <library>/boost/timer//boost_timer
     ;
 
 


### PR DESCRIPTION
Resolved drawing both static and shared libraries when building  
[ test-btl-lib run : basic_cstring_test    : boost_unit_test_framework/<link>static ]
which requires only static libraries.
